### PR TITLE
Start ReplayGainsayer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ It will then act to determine the loudness of each album (not each track) in som
 The output is a list of albums and a red-yellow-green classification system for albums that have been "brick walled" (greater than -6 dBfs, with an icon of a red brick wall), significantly compressed (-11 to -6 dBfs, with an icon of a clamp or vice squeezing a yellow folder, reminiscent of the WinZip icon), or reasonably dynamic (less than -11 dBfs, with a happy green icon).
 
 Eventually, ReplayGainsayer may help fans to discover the best masters across streaming platforms and choose to listen to better music.
+
+## Development
+
+Install dependencies with::
+
+    pip install -r requirements.txt
+
+To run the command line interface::
+
+    python -m replaygainsayer ARTIST_NAME --client-id YOUR_ID --client-secret YOUR_SECRET
+
+This will query Spotify for the artist's albums and print placeholder loudness information.

--- a/replaygainsayer/__init__.py
+++ b/replaygainsayer/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for ReplayGainsayer."""
+
+__all__ = [
+    "services",
+    "loudness",
+    "cli",
+]

--- a/replaygainsayer/__main__.py
+++ b/replaygainsayer/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ReplayGainsayer."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/replaygainsayer/cli.py
+++ b/replaygainsayer/cli.py
@@ -1,0 +1,36 @@
+"""Command line interface for ReplayGainsayer."""
+
+import argparse
+from typing import List
+
+from .services import SpotifyService, Album
+from .loudness import classify_loudness
+
+
+class CLI:
+    """Main CLI handler."""
+
+    def __init__(self) -> None:
+        self.parser = argparse.ArgumentParser(description=__doc__)
+        self.parser.add_argument("artist", help="Artist name to search for")
+        self.parser.add_argument("--client-id", required=True)
+        self.parser.add_argument("--client-secret", required=True)
+
+    def run(self, argv: List[str] | None = None) -> None:
+        args = self.parser.parse_args(argv)
+        service = SpotifyService(args.client_id, args.client_secret)
+        albums = service.get_albums(args.artist)
+        print(f"Found {len(albums)} albums for {args.artist}:")
+        for album in albums:
+            # Placeholder: we have no audio to measure, so display album name only
+            lufs = -12.0  # fake value for demonstration
+            label = classify_loudness(lufs)
+            print(f"  {album.name} -> {label} ({lufs} LUFS)")
+
+
+def main(argv: List[str] | None = None) -> None:
+    CLI().run(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/replaygainsayer/loudness.py
+++ b/replaygainsayer/loudness.py
@@ -1,0 +1,27 @@
+"""Loudness analysis utilities."""
+
+from typing import Iterable
+
+try:
+    import pyloudnorm as pyln
+except ImportError:  # pragma: no cover - pyloudnorm is optional
+    pyln = None  # type: ignore
+
+
+def measure_loudness(samples: Iterable[float], sample_rate: int) -> float:
+    """Return integrated loudness in LUFS for the given audio samples."""
+    if pyln is None:
+        raise RuntimeError(
+            "pyloudnorm is required for loudness measurement. Install it via pip."
+        )
+    meter = pyln.Meter(sample_rate)
+    return meter.integrated_loudness(samples)
+
+
+def classify_loudness(lufs: float) -> str:
+    """Return RYG classification for a given loudness level."""
+    if lufs > -6:
+        return "red"
+    if -11 < lufs <= -6:
+        return "yellow"
+    return "green"

--- a/replaygainsayer/services.py
+++ b/replaygainsayer/services.py
@@ -1,0 +1,45 @@
+"""Streaming service integrations for ReplayGainsayer."""
+
+from dataclasses import dataclass
+from typing import List
+
+try:
+    import spotipy
+    from spotipy import Spotify
+    from spotipy.oauth2 import SpotifyClientCredentials
+except ImportError:  # pragma: no cover - spotipy is optional
+    spotipy = None  # type: ignore
+
+
+@dataclass
+class Album:
+    """Basic album representation."""
+
+    name: str
+    id: str
+
+
+class BaseService:
+    """Base class for streaming service implementations."""
+
+    def get_albums(self, artist_name: str) -> List[Album]:
+        raise NotImplementedError
+
+
+class SpotifyService(BaseService):
+    """Interact with the Spotify API to fetch albums."""
+
+    def __init__(self, client_id: str, client_secret: str):
+        if spotipy is None:
+            raise RuntimeError(
+                "spotipy is required for Spotify integration. Install it via pip."
+            )
+        creds = SpotifyClientCredentials(client_id=client_id, client_secret=client_secret)
+        self.api = Spotify(client_credentials_manager=creds)
+
+    def get_albums(self, artist_name: str) -> List[Album]:
+        results = self.api.search(q=f"artist:{artist_name}", type="album")
+        albums = []
+        for item in results.get("albums", {}).get("items", []):
+            albums.append(Album(name=item["name"], id=item["id"]))
+        return albums

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+spotipy
+pyloudnorm


### PR DESCRIPTION
## Summary
- set up Python package skeleton for ReplayGainsayer
- add Spotify API service module
- add loudness analysis utilities
- build CLI entry point
- document install and usage

## Testing
- `pip install -r requirements.txt`
- `python -m replaygainsayer -h`
- `python -m replaygainsayer test --client-id foo --client-secret bar` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_687648f45f90832c9cdf6a31729759ab