### PR TITLE
Add virtualenv setup and staged plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ ReplayGainsayer helps music fans identify the best masters of their favorite mus
 
 Eventually, ReplayGainsayer may help fans to discover the best masters across streaming platforms and choose to listen to better music.
 
-## Development
-
 ## Staged development plan
 
 1. **Spotify prototype**
@@ -30,20 +28,44 @@ Eventually, ReplayGainsayer may help fans to discover the best masters across st
 
 ## Installation
 
-Clone the repository and install dependencies using pip:
+Clone the repository and set up a Python virtual environment so dependencies do not pollute your base system:
 
 ```bash
- git clone https://example.com/ReplayGainsayer.git
- cd ReplayGainsayer
- pip install -r requirements.txt
+git clone https://example.com/ReplayGainsayer.git
+cd ReplayGainsayer
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Spotify credentials
+
+Create an application on the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) to obtain a **Client ID** and **Client Secret**. Store them in environment variables:
+
+```bash
+export SPOTIFY_CLIENT_ID=<your client id>
+export SPOTIFY_CLIENT_SECRET=<your client secret>
 ```
 
 ## Usage
 
-Run the tool with an artist name to see loudness information:
+Run the tool with an artist name, passing in the credentials from the environment:
 
 ```bash
- python -m replaygainsayer --artist "Artist Name"
+python -m replaygainsayer "Artist Name" \
+  --client-id "$SPOTIFY_CLIENT_ID" \
+  --client-secret "$SPOTIFY_CLIENT_SECRET"
+```
+
+The script `scripts/run_black_sabbath.sh` demonstrates running the program for the band **Black Sabbath**.
+
+## Development
+
+Run the automated tests with `pytest`:
+
+```bash
+pip install pytest
+pytest
 ```
 
 Contributions and ideas are welcome!

--- a/scripts/run_black_sabbath.sh
+++ b/scripts/run_black_sabbath.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Simple script to run ReplayGainsayer for the band Black Sabbath.
+# Requires SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET environment variables.
+
+if [[ -z "$SPOTIFY_CLIENT_ID" || -z "$SPOTIFY_CLIENT_SECRET" ]]; then
+  echo "Please set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET env vars." >&2
+  exit 1
+fi
+
+python -m replaygainsayer "Black Sabbath" \
+  --client-id "$SPOTIFY_CLIENT_ID" \
+  --client-secret "$SPOTIFY_CLIENT_SECRET"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import builtins
+from unittest import mock
+
+from replaygainsayer.cli import CLI
+from replaygainsayer.services import Album
+
+
+def test_cli_lists_black_sabbath_albums(capsys):
+    albums = [
+        Album(name="Paranoid", id="1"),
+        Album(name="Master of Reality", id="2"),
+    ]
+    with mock.patch("replaygainsayer.cli.SpotifyService") as service_cls:
+        service_cls.return_value.get_albums.return_value = albums
+        CLI().run(["Black Sabbath", "--client-id", "id", "--client-secret", "secret"])
+    output = capsys.readouterr().out
+    assert "Found 2 albums for Black Sabbath:" in output
+    assert "Paranoid" in output
+    assert "Master of Reality" in output


### PR DESCRIPTION
## Summary
- describe staged development plan again
- document using a Python virtual environment
- explain how to store Spotify credentials and run the example script
- add a basic CLI test and Black Sabbath helper script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687666aa9990832cb385193eeb44a214